### PR TITLE
Update to the ServiceStack version dependency

### DIFF
--- a/src/Nancy.Serialization.ServiceStack/Nancy.Serialization.ServiceStack/Nancy.Serialization.ServiceStack.nuspec
+++ b/src/Nancy.Serialization.ServiceStack/Nancy.Serialization.ServiceStack/Nancy.Serialization.ServiceStack.nuspec
@@ -14,7 +14,7 @@
     <projectUrl>http://nancyfx.org</projectUrl>
     <dependencies>
       <dependency id="Nancy" />
-      <dependency id="ServiceStack.Text" version="3.9.5" />
+      <dependency id="ServiceStack.Text" version="[3.9.5,4)" />
     </dependencies>
     <tags>Nancy Json ServiceStack</tags>
   </metadata>


### PR DESCRIPTION
Since SS v4 is a major change including licensing and commercial use, this limits the dependencies to the v3 releases.
