### PR TITLE
Prevent TargetException when getting property value

### DIFF
--- a/src/Nancy.Serialization.ServiceStack/Nancy.Serialization.ServiceStack/ServiceStackBodyDeserializer.cs
+++ b/src/Nancy.Serialization.ServiceStack/Nancy.Serialization.ServiceStack/ServiceStackBodyDeserializer.cs
@@ -32,6 +32,10 @@
         public object Deserialize(string contentType, Stream bodyStream, BindingContext context)
         {
             var deserializedObject = JsonSerializer.DeserializeFromStream(context.DestinationType, bodyStream);
+            if (deserializedObject == null)
+            {
+                return null;
+            }
 
             if (context.DestinationType.GetProperties(BindingFlags.Public | BindingFlags.Instance).Except(context.ValidModelProperties).Any())
             {


### PR DESCRIPTION
Fixes https://github.com/NancyFx/Nancy/issues/1554

When the SS.Text `JsonSerializer.DeserializeFromStream` gets an empty stream, it returns `null`, which in turn blows up in the `property.GetValue(sourceObject, null)` call below (`sourceObject` is `null`).
