### PR TITLE
Made the compile tasks depend on the nuget restore tasks

### DIFF
--- a/rakefile.rb
+++ b/rakefile.rb
@@ -17,7 +17,7 @@ Albacore.configure do |config|
 end
 
 desc "Compiles solution and runs unit tests"
-task :default => [:clean, :version, :nuget_restore, :compile, :publish, :package]
+task :default => [:clean, :version, :compile, :publish, :package]
 
 #Add the folders that should be cleaned as part of the clean task
 CLEAN.include(OUTPUT)
@@ -44,7 +44,7 @@ exec :nuget_restore do |cmd|
 end
 
 desc "Compile solution file"
-msbuild :compile => [:version] do |msb|
+msbuild :compile => [:nuget_restore, :version] do |msb|
     msb.properties :configuration => CONFIGURATION
     msb.targets :Clean, :Build
     msb.solution = SOLUTION_FILE


### PR DESCRIPTION
Changed so `default` task doesn't depend on the nuget restore tasks. Those dependencies have instead been moved to the `compile` task. This will ensure that if you run as task such as `nuget_package` it will actually make sure that a package restore has been executed prior to compiling.