### PR TITLE
Fixed build.ps1 verbosity

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ install:
 - git submodule update --init --recursive
 
 build_script:
-- ps: .\build.ps1 -verbosity diagnostic
+- ps: .\build.ps1 -verbosity=normal
 
 artifacts:
 - path: build\nuget\*.nupkg


### PR DESCRIPTION
We where missing a `=` in `-verbosity=diagnostic`, causing builds to fail but still generate a false positive 😢 